### PR TITLE
Fix bug with ->send() return wrong response

### DIFF
--- a/src/Chat.php
+++ b/src/Chat.php
@@ -19,7 +19,7 @@ class Chat {
         $response = new Response($request);
         if ($this->client->debug)
         {
-            if (!$response->isOkay())
+            if ($response->isOkay())
             {
                 echo $this->client->config['username'].' ['.$this->channel.']: '.$message.PHP_EOL;
                 return true;


### PR DESCRIPTION
In debug mode, ->send() will return an error on success, an vice versa. This fixes that.
