### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ $config = [
     'token' => 'USER-API-TOKEN',
     'team' => 'YOUR-TEAM',
     'username' => 'BOT-NAME',
-    'icon' => 'ICON' // Auto detects if it's an icon_url or icon_emoji
+    'icon' => 'ICON', // Auto detects if it's an icon_url or icon_emoji
+    'parse' => '', // __construct function in Client.php calls for the parse parameter 
 ];
 
 $slack = new Client($config);


### PR DESCRIPTION
When executing the example in the readme, a PHP notice occurs due to not including the "parse" parameter in the $config array. I haven't looked too deeply into the src so I'm not sure what is supposed to go here. Bool value?
