### PR TITLE
Tweaks

### DIFF
--- a/src/Chat.php
+++ b/src/Chat.php
@@ -11,10 +11,10 @@ class Chat {
         $this->channel = $channel;
     }
 
-    public function send($message = null)
+    public function send($message = null, $attachments = null)
     {
         $config = $this->client->getConfig();
-        $query = array_merge(array('text' => $message, 'channel' => $this->channel), $config);
+        $query = array_merge(array('text' => $message, 'channel' => $this->channel, 'attachments' => json_encode($attachments)), $config);
         $request = $this->client->request('chat.postMessage', $query)->send();
         $response = new Response($request);
         if ($this->client->debug)

--- a/src/Chat.php
+++ b/src/Chat.php
@@ -27,7 +27,7 @@ class Chat {
             else
             {
                 echo '[Error] '.$response->getError().'.'.PHP_EOL;
-		echo '[Query] '.var_export($this->client->request('chat.postMessage', $query)->getQuery(), true);
+                echo '[Query] '.var_export($this->client->request('chat.postMessage', $query)->getQuery(), true);
                 return false;
             }
         }

--- a/src/Chat.php
+++ b/src/Chat.php
@@ -21,12 +21,13 @@ class Chat {
         {
             if ($response->isOkay())
             {
-                echo $this->client->config['username'].' ['.$this->channel.']: '.$message.PHP_EOL;
+                //echo $this->client->config['username'].' ['.$this->channel.']: '.$message.PHP_EOL;
                 return true;
             }
             else
             {
                 echo '[Error] '.$response->getError().'.'.PHP_EOL;
+		echo '[Query] '.var_export($this->client->request('chat.postMessage', $query)->getQuery(), true);
                 return false;
             }
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -82,7 +82,7 @@ class Client {
 
     public function users()
     {
-        $query = $this->getConfig(['token']);
+        $query = $this->getConfig(array('token'));
         $response = $this->request('users.list', $query)->send()->json();
         $users = array();
         foreach ($response['members'] as $member)

--- a/src/Webhooks/Incoming.php
+++ b/src/Webhooks/Incoming.php
@@ -21,7 +21,7 @@ class Incoming {
 
     public function getPayload($key = null)
     {
-        return is_null($key) ? $this->payload : $this->payload[$key];
+        return is_null($key) ? $this->payload : @$this->payload[$key];
     }
 
     public function token()
@@ -41,7 +41,7 @@ class Incoming {
 
     public function channel()
     {
-        return $this->getPayload('channel_name');
+        return $this->getPayload('channel_id');
     }
 
     public function timestamp()
@@ -84,7 +84,7 @@ class Incoming {
 
     public function respond($response, $channel = null)
     {
-        $channel = is_null($channel) ? '#'.$this->channel() : $channel;
+        $channel = is_null($channel) ? $this->channel() : $channel;
         return $this->client->chat($channel)->send($response);
     }
 }

--- a/src/Webhooks/Incoming.php
+++ b/src/Webhooks/Incoming.php
@@ -71,8 +71,13 @@ class Incoming {
 
     public function trigger()
     {
-        $words = $this->words();
-        return substr($words[0], 0, -1);
+        if ($this->getPayload('trigger_word')) {
+            return $this->getPayload('trigger_word');
+        }
+        else if ($this->getPayload('command')) {
+            return $this->getPayload('command');
+        }
+        return "";
     }
 
     public function text()


### PR DESCRIPTION
- Allow SDK to work with earlier versions of PHP.
- Allow 'attachment' messages: https://db.tt/z6fjuvlw
- Don't echo status response on success, this prevents the class being used embedded in a rest API, causing requests to look like they failed.
- Add performed query to Error output, which helps debug query issues (potential improvement: should throw exception on error).
- Allow messages to be targeted at private channels (switches hooks to use channel_id rather than name).
- Use API to extract 'trigger_word' and slack 'command', rather than trimming input text.

